### PR TITLE
fix: set cookie secure flag from request scheme, break auth error loop

### DIFF
--- a/app/[locale]/auth/page.tsx
+++ b/app/[locale]/auth/page.tsx
@@ -7,11 +7,15 @@ import { Spinner } from "@/components/ui/spinner";
 
 export default function AuthPage() {
   const searchParams = useSearchParams();
+  const error = searchParams.get("error");
 
   useEffect(() => {
+    // Don't re-enter the login flow if we landed here from a failed callback —
+    // that would loop indefinitely.
+    if (error) return;
     const redirect = searchParams.get("redirect") || "/admin";
     window.location.href = `/api/auth/login?redirect=${encodeURIComponent(redirect)}`;
-  }, [searchParams]);
+  }, [searchParams, error]);
 
   return (
     <div className="flex-1 flex items-start justify-center px-4 pt-24">
@@ -32,11 +36,30 @@ export default function AuthPage() {
         />
 
         <div className="flex flex-col items-center gap-4 text-center">
-          <Spinner className="size-6 text-white/40" />
-          <p className="text-base font-medium text-white/90">Signing you in</p>
-          <p className="text-sm text-white/40 max-w-xs">
-            You're being redirected to the authentication provider
-          </p>
+          {error ? (
+            <>
+              <p className="text-base font-medium text-white/90">
+                Sign-in failed
+              </p>
+              <p className="text-sm text-white/40 max-w-xs">{error}</p>
+              <a
+                href="/api/auth/login"
+                className="text-sm font-medium text-white/90 underline"
+              >
+                Try again
+              </a>
+            </>
+          ) : (
+            <>
+              <Spinner className="size-6 text-white/40" />
+              <p className="text-base font-medium text-white/90">
+                Signing you in
+              </p>
+              <p className="text-sm text-white/40 max-w-xs">
+                You're being redirected to the authentication provider
+              </p>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
-import { publicOrigin } from "@/lib/origin";
+import { isSecureRequest, publicOrigin } from "@/lib/origin";
 
 const SERVER = process.env.SERVER_URL ?? process.env.NEXT_PUBLIC_SERVER!;
 const ACCESS_TOKEN_MAX_AGE = 15 * 60; // matches backend access-token lifetime
@@ -51,7 +51,7 @@ export async function GET(req: NextRequest) {
     refresh_token?: string;
   };
 
-  const secure = process.env.NODE_ENV === "production";
+  const secure = isSecureRequest(req);
   jar.set("daab.accessToken", tokens.access_token, {
     httpOnly: true,
     sameSite: "lax",

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import { cookies } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
-import { publicOrigin } from "@/lib/origin";
+import { isSecureRequest, publicOrigin } from "@/lib/origin";
 
 const SERVER = process.env.SERVER_URL ?? process.env.NEXT_PUBLIC_SERVER!;
 const CLIENT_ID = process.env.OAUTH_CLIENT_ID ?? "test-client-id";
@@ -33,7 +33,7 @@ export async function GET(req: NextRequest) {
     sameSite: "lax",
     path: "/",
     maxAge: 600,
-    secure: process.env.NODE_ENV === "production",
+    secure: isSecureRequest(req),
   });
 
   const authorizeUrl = new URL(`${SERVER}/authorize`);

--- a/lib/origin.ts
+++ b/lib/origin.ts
@@ -14,3 +14,10 @@ export function publicOrigin(req: NextRequest): string {
 
   return host ? `${proto}://${host}` : req.nextUrl.origin;
 }
+
+// Whether the public-facing connection is HTTPS. Used to decide the `secure`
+// cookie flag — forcing `secure` on a plain-HTTP deployment makes the browser
+// silently drop the cookie.
+export function isSecureRequest(req: NextRequest): boolean {
+  return publicOrigin(req).startsWith("https://");
+}


### PR DESCRIPTION
On a plain-HTTP deployment the session cookies were set with secure=true (NODE_ENV==="production"), so the browser silently dropped them. The oauth_tx cookie never persisted, the callback saw no tx state and returned error=invalid_request, and the auth page immediately re-entered the login flow — an infinite redirect loop.

- isSecureRequest(): secure only when the public origin is https
- login/callback cookies use it instead of NODE_ENV
- auth page: skip auto-login when ?error is present and show a "Sign-in failed / Try again" state instead of looping